### PR TITLE
Replace bitflate uri back to bitcoin before passing to bip21

### DIFF
--- a/class/deeplink-schema-match.js
+++ b/class/deeplink-schema-match.js
@@ -442,7 +442,7 @@ class DeeplinkSchemaMatch {
 
   static bip21decode(uri) {
     if (!uri) return {};
-    return bip21.decode(uri.replace('BITFLATE:', 'bitflate:'));
+    return bip21.decode(uri.replace('BITCOIN:', 'bitcoin:').replace('BITFLATE:', 'bitcoin:').replace('bitflate:', 'bitcoin:'));
   }
 
   static bip21encode() {


### PR DESCRIPTION
Avoid URI parsing error.